### PR TITLE
bulk: allow prefetching binary packages from official repos

### DIFF
--- a/src/bin/poudriere-bulk.8
+++ b/src/bin/poudriere-bulk.8
@@ -40,6 +40,7 @@
 .Fl a
 .Fl j Ar name
 .Op Fl CcFIikNnRrSTtvw
+.Op Fl b Ar name
 .Op Fl B Ar name
 .Op Fl J Ar maxjobs Ns Op Cm \&: Ns Ar prebuildmaxjobs
 .Op Fl O Ar overlays
@@ -50,6 +51,7 @@
 .Fl f Ar file Op Oo Fl f Ar file2 Oc Ar ...
 .Fl j Ar name
 .Op Fl CcFIikNnRrSTtvw
+.Op Fl b Ar name
 .Op Fl B Ar name
 .Op Fl J Ar maxjobs Ns Op Cm \&: Ns Ar prebuildmaxjobs
 .Op Fl O Ar overlays
@@ -59,6 +61,7 @@
 .Cm bulk
 .Fl j Ar name
 .Op Fl CcFIikNnRrSTtvw
+.Op Fl b Ar name
 .Op Fl B Ar name
 .Op Fl J Ar maxjobs Ns Op Cm \&: Ns Ar prebuildmaxjobs
 .Op Fl O Ar overlays
@@ -111,6 +114,17 @@ arguments may be specified at once.
 .El
 .Sh OPTIONS
 .Bl -tag -width "-B name"
+.It Fl b Ar name
+Specify the
+.Ar name
+of the binary package branch to use to prefetch packages.
+Should be
+.Qq latest
+or
+.Qq quarterly .
+With this option poudriere will first try to fetch from the binary package
+repository specified the binary package prior to do the sanity check if the
+package does not already exist.
 .It Fl B Ar name
 Specify which buildname to use.
 By default

--- a/src/share/poudriere/bulk.sh
+++ b/src/share/poudriere/bulk.sh
@@ -38,6 +38,8 @@ Options:
     -B name     -- What buildname to use (must be unique, defaults to
                    YYYY-MM-DD_HH:MM:SS). Resuming a previous build will not
                    retry built/failed/skipped/ignored packages.
+    -b branch   -- Branch to chose for fetching packages from official
+                   repositories: valid options are: latest, quarterly
     -C          -- Clean only the packages listed on the command line or
                    -f file.  Implies -c for -a.
     -c          -- Clean all the previously built binary packages and logs.
@@ -92,13 +94,21 @@ OVERLAYS=""
 
 [ $# -eq 0 ] && usage
 
-while getopts "aB:CcFf:iIj:J:knNO:p:RrSTtvwz:" FLAG; do
+while getopts "ab:B:CcFf:iIj:J:knNO:p:RrSTtvwz:" FLAG; do
 	case "${FLAG}" in
 		a)
 			ALL=1
 			;;
 		B)
 			BUILDNAME="${OPTARG}"
+			;;
+		b)
+			PACKAGE_BRANCH="${OPTARG}"
+			case "${PACKAGE_BRANCH}" in
+			latest|quarterly) ;;
+			*)
+				err 1 "Invalid branch name for packages: ${OPTARG}"
+			esac
 			;;
 		c)
 			CLEAN=1

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -2940,6 +2940,29 @@ jail_cleanup() {
 	export CLEANED_UP=1
 }
 
+download_from_repo() {
+	msg "Prefetching missing packages from pkg+http://pkg.freebsd.org/\${ABI}/${PACKAGE_BRANCH}"
+	cat >> ${MASTERMNT}/etc/pkg/poudriere.conf <<EOF
+FreeBSD: {
+        url: pkg+http://pkg.freebsd.org/\${ABI}/${PACKAGE_BRANCH};
+}
+EOF
+	umount ${UMOUNT_NONBUSY} ${MASTERMNT}/packages || \
+	    umount -f ${MASTERMNT}/packages
+	mount_packages
+	# only list packages which do not exists to prevent pkg from overwriting prebuilt packages
+	# XXX only work when PKG_EXT is the same as the upstream
+	(
+	while mapfile_read_loop "all_pkgs" pkgname originspec _ignored; do
+		[ -f ${MASTERMNT}/packages/All/${pkgname}.${PKG_EXT} ] || echo ${pkgname}
+	done
+	)| JNETNAME="n" injail xargs env -i ASSUME_ALWAYS_YES=yes pkg fetch -o /packages
+	# Remount ro
+	umount ${UMOUNT_NONBUSY} ${MASTERMNT}/packages || \
+	    umount -f ${MASTERMNT}/packages
+	mount_packages -o ro
+}
+
 # return 0 if the package dir exists and has packages, 0 otherwise
 package_dir_exists_and_has_packages() {
 	[ ! -d ${PACKAGES}/All ] && return 1
@@ -7369,6 +7392,10 @@ prepare_ports() {
 			:> ${log}/.poudriere.ports.skipped
 			trim_ignored
 		fi
+	fi
+
+	if [ -n "${PACKAGE_BRANCH}" ]; then
+		download_from_repo
 	fi
 
 	if ! ensure_pkg_installed && [ ${SKIPSANITY} -eq 0 ]; then


### PR DESCRIPTION
As soon as we have the entire list of packages to build but before
the sanity check, pre fetch all the binary packages that we can
from the official repositories.

The sanity check running after than will probably destroy some
packages for which the confiration will be different or any reason
suitable for the sanity check to destroy packages.

When listing the packages to fetch only list the one not already
existing to avoid pkg fetch to redownload and overwrite packages
we have already customized